### PR TITLE
Browar Haust [RIP], grudzień 2023

### DIFF
--- a/resources/trips/2023-12-28-zielona-gora.json
+++ b/resources/trips/2023-12-28-zielona-gora.json
@@ -1,0 +1,25 @@
+{
+  "name": "Zielona Góra, grudzień 2023",
+  "breweries": [
+    {
+      "name": "Browar Haust",
+      "visited": "2023-12-28",
+      "location": {
+        "country": "pl",
+        "city": "Zielona Góra",
+        "address": "pl. Pocztowy 9",
+        "coordinates": {
+          "lat": 51.93743553187676,
+          "lng": 15.506938188365282
+        }
+      },
+      "tags": [
+        "piwo spróbowane poza browarem",
+        "obejrzany sprzęt",
+        "brewpub",
+        "województwo lubuskie",
+        "obecnie zamknięty"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Ostatni dzień funkcjonowania browaru [*]

![obraz](https://github.com/krzysztofrewak/browary/assets/10898728/5d6b4c8d-5a1d-4544-8d6b-ee6901a87dbc)

